### PR TITLE
커서 페이징 구조 개선 | 베이커리 기타메뉴 대응

### DIFF
--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -5,14 +5,19 @@ from fastapi import APIRouter, Depends, File, Form, Query, UploadFile
 from app.core.auth import get_user_id, verify_token
 from app.core.base import BaseResponse
 from app.core.database import get_db
-from app.core.exception import ERROR_INVALID_AREA_CODE, ERROR_NOT_FOUND, ERROR_UNKNOWN
+from app.core.exception import (
+    ERROR_INVALID_AREA_CODE,
+    ERROR_INVALID_FILE_CONTENT_TYPE,
+    ERROR_NOT_FOUND,
+    ERROR_UNKNOWN,
+)
 from app.schema.bakery import (
     BakeryDetailResponseDTO,
     LoadMoreBakeryResponseDTO,
     RecommendBakery,
     SimpleBakeryMenu,
 )
-from app.schema.review import BakeryReviewReponseDTO, MyBakeryReview
+from app.schema.review import BakeryMyReviewReponseDTO, BakeryReviewReponseDTO
 from app.services.bakery_service import BakeryService
 from app.services.review_service import Review
 
@@ -48,16 +53,16 @@ async def get_bakeries_by_preference(
     response_model=BaseResponse[LoadMoreBakeryResponseDTO],
     responses={**ERROR_UNKNOWN, **ERROR_INVALID_AREA_CODE},
     response_description="""
-    paging.cursor.after값이 -1이면 더이상 요청할 수 있는 다음 페이지가 없다는 뜻.
+    paging.has_next가 False면 더이상 요청할 수 있는 다음 페이지가 없다는 뜻.
     """,
 )
 async def get_preference_bakery(
     area_code: str = Query(
         description="지역 코드 (쉼표로 여러 개 전달 가능, 예: '1, 2, 3')"
     ),
-    cursor_id: int = Query(
-        default=0,
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.cursor.after 값을 사용해서 조회.",
+    cursor_value: str = Query(
+        default="0",
+        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
     ),
     page_size: int = Query(default=15),
     user_id=Depends(get_user_id),
@@ -67,7 +72,7 @@ async def get_preference_bakery(
 
     return BaseResponse(
         data=await BakeryService(db=db).get_more_bakeries_by_preference(
-            cursor_id=cursor_id,
+            cursor_value=cursor_value,
             page_size=page_size,
             area_code=area_code,
             user_id=user_id,
@@ -100,16 +105,16 @@ async def get_recommend_bakery_by_area(
     response_model=BaseResponse[LoadMoreBakeryResponseDTO],
     responses={**ERROR_UNKNOWN, **ERROR_INVALID_AREA_CODE},
     response_description="""
-    1. 500 에러 예시 : DB 이슈
+    paging.has_next가 False면 더이상 요청할 수 있는 다음 페이지가 없다는 뜻.
     """,
 )
 async def get_hot_bakeries(
     area_code: str = Query(
         description="지역 코드 (쉼표로 여러 개 전달 가능, 예: '1, 2, 3')"
     ),
-    cursor_id: int = Query(
-        default=0,
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.cursor.after 값을 사용해서 조회.",
+    cursor_value: str = Query(
+        default="0",
+        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
     ),
     page_size: int = Query(default=15),
     _: None = Depends(get_user_id),
@@ -119,7 +124,7 @@ async def get_hot_bakeries(
 
     return BaseResponse(
         data=await BakeryService(db=db).get_hot_bakeries(
-            area_code=area_code, cursor_id=cursor_id, page_size=page_size
+            area_code=area_code, cursor_value=cursor_value, page_size=page_size
         )
     )
 
@@ -150,12 +155,21 @@ async def get_bakery_menus(
     )
 
 
-@router.get("/{bakery_id}/reviews", response_model=BaseResponse[BakeryReviewReponseDTO])
+@router.get(
+    "/{bakery_id}/reviews",
+    response_model=BaseResponse[BakeryReviewReponseDTO],
+    response_description="""
+    paging.has_next가 False면 더이상 요청할 수 있는 다음 페이지가 없다는 뜻.
+    """,
+)
 async def get_reviews_by_bakery_id(
     bakery_id: int,
-    cursor_id: int = Query(
-        default=0,
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.cursor.after 값을 사용해서 조회.",
+    cursor_value: str = Query(
+        default="0:0",
+        description="""
+    처음엔 0:0으로 넘겨주고, 
+    그 다음부턴 response 내 next_cursor값을 입력해주세요.
+        """,
     ),
     page_size: int = Query(default=5),
     sort_clause: str = Query(
@@ -177,19 +191,21 @@ async def get_reviews_by_bakery_id(
         data=await Review(db=db).get_reviews_by_bakery_id(
             user_id=user_id,
             bakery_id=bakery_id,
-            cursor_id=cursor_id,
+            cursor_value=cursor_value,
             page_size=page_size,
             sort_clause=sort_clause,
         )
     )
 
 
-@router.get("/{bakery_id}/my-review", response_model=BaseResponse[List[MyBakeryReview]])
+@router.get(
+    "/{bakery_id}/my-review", response_model=BaseResponse[BakeryMyReviewReponseDTO]
+)
 async def get_my_bakery_review(
     bakery_id: int,
-    cursor_id: int = Query(
+    cursor_value: str = Query(
         default=0,
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.cursor.after 값을 사용해서 조회.",
+        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
     ),
     page_size: int = Query(default=5),
     user_id=Depends(get_user_id),
@@ -201,7 +217,7 @@ async def get_my_bakery_review(
         data=await Review(db=db).get_my_reviews_by_bakery_id(
             bakery_id=bakery_id,
             user_id=user_id,
-            cursor_id=cursor_id,
+            cursor_value=cursor_value,
             page_size=page_size,
         )
     )

--- a/app/core/const.py
+++ b/app/core/const.py
@@ -1,0 +1,1 @@
+ETC_MENU_NAME = "기타메뉴"

--- a/app/model/review.py
+++ b/app/model/review.py
@@ -47,4 +47,3 @@ class ReviewBakeryMenu(Base, DateTimeMixin):
     review_id = Column(Integer, nullable=False, comment="리뷰 ID")
     menu_id = Column(Integer, nullable=False, comment="메뉴 ID")
     quantity = Column(Integer, nullable=False, comment="수량")
-    unit_price = Column(Float, comment="단위 가격")

--- a/app/repositories/bakery_repo.py
+++ b/app/repositories/bakery_repo.py
@@ -2,6 +2,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.session import Session
 
+from app.core.const import ETC_MENU_NAME
 from app.core.exception import NotFoundError, UnknownError
 from app.model.bakery import (
     Bakery,
@@ -507,11 +508,20 @@ class BakeryRepository:
                 .all()
             )
 
-            return [
+            menus = [
                 SimpleBakeryMenu(
                     menu_id=r.id, menu_name=r.name, is_signature=r.is_signature
                 )
                 for r in res
             ]
+
+            if all(menu.menu_name != ETC_MENU_NAME for menu in menus):
+
+                menus.append(
+                    SimpleBakeryMenu(
+                        menu_id=-1, menu_name=ETC_MENU_NAME, is_signature=False
+                    )
+                )
+            return menus
         except Exception as e:
             raise UnknownError(detail=str(e))

--- a/app/repositories/bakery_repo.py
+++ b/app/repositories/bakery_repo.py
@@ -116,7 +116,7 @@ class BakeryRepository:
 
     async def get_more_bakeries_by_preference(
         self,
-        cursor_id: int,
+        cursor_value: str,
         page_size: int,
         area_codes: list[str],
         user_id: int,
@@ -126,7 +126,7 @@ class BakeryRepository:
 
         conditions = [
             UserPreferences.user_id == user_id,
-            Bakery.id > cursor_id,
+            Bakery.id > cursor_value,
             BakeryPhoto.is_signature == True,
         ]
 
@@ -180,10 +180,13 @@ class BakeryRepository:
                 )
                 .where(and_(*conditions))
                 .order_by(Bakery.id.asc())
-                .limit(page_size)
+                .limit(page_size + 1)
             )
 
             res = self.db.execute(stmt).mappings().all()
+
+            has_next = len(res) > page_size
+
             return [
                 LoadMoreBakery(
                     bakery_id=r.id,
@@ -201,8 +204,8 @@ class BakeryRepository:
                     gu=r.gu,
                     dong=r.dong,
                 )
-                for r in res
-            ]
+                for r in res[:page_size]
+            ], has_next
         except Exception as e:
             raise UnknownError(detail=str(e))
 
@@ -291,17 +294,17 @@ class BakeryRepository:
 
     async def get_more_hot_bakeries(
         self,
-        cursor_id: int,
+        cursor_value: str,
         page_size: int,
         area_codes: list[str],
         target_day_of_week: int,
     ):
         """(더보기) hot한 빵집 조회하는 쿼리"""
 
-        conditions = [Bakery.id > cursor_id, BakeryPhoto.is_signature == True]
+        filters = [Bakery.id > cursor_value, BakeryPhoto.is_signature == True]
 
         if area_codes != ["14"]:
-            conditions.append(Bakery.commercial_area_id.in_(area_codes))
+            filters.append(Bakery.commercial_area_id.in_(area_codes))
 
         stmt = (
             select(
@@ -339,12 +342,13 @@ class BakeryRepository:
                 and_(UserBakeryLikes.bakery_id == Bakery.id),
                 isouter=True,
             )
-            .where(and_(*conditions))
+            .where(and_(*filters))
             .order_by(Bakery.id, Bakery.avg_rating.desc())
-            .limit(page_size)
+            .limit(page_size + 1)
         )
 
         res = self.db.execute(stmt).mappings().all()
+        has_next = len(res) > page_size
 
         return [
             LoadMoreBakery(
@@ -363,8 +367,8 @@ class BakeryRepository:
                 gu=r.gu,
                 dong=r.dong,
             )
-            for r in res
-        ]
+            for r in res[:page_size]
+        ], has_next
 
     async def get_bakery_detail(self, bakery_id: int, target_day_of_week: int):
         """베이커리 상세정보 조회하는 쿼리."""

--- a/app/repositories/review_repo.py
+++ b/app/repositories/review_repo.py
@@ -1,11 +1,14 @@
-from typing import List, Optional
+from typing import List
 
-from sqlalchemy import and_, asc, desc, select
+from sqlalchemy import and_, select
 
+from app.core.exception import UnknownError
 from app.model.bakery import Bakery, BakeryMenu
 from app.model.review import Review, ReviewBakeryMenu, ReviewLike, ReviewPhoto
 from app.model.users import Users
 from app.schema.review import BakeryReview, MyBakeryReview
+from app.utils.date import get_today_end, get_today_start
+from app.utils.pagination import build_cursor_filter, build_order_by, parse_cursor_value
 
 
 class ReviewRepository:
@@ -13,9 +16,19 @@ class ReviewRepository:
         self.db = db
 
     async def get_my_reviews_by_bakery_id(
-        self, bakery_id: int, user_id: int, cursor_id: int, page_size: int
+        self, bakery_id: int, user_id: int, cursor_value: str, page_size: int
     ):
         """리뷰 주요데이터 조회하는 쿼리."""
+
+        filters = [
+            Users.id == user_id,
+            Review.bakery_id == bakery_id,
+        ]
+
+        if cursor_value != "0":
+            filters.append(
+                Review.id < cursor_value,
+            )
 
         stmt = (
             select(
@@ -34,16 +47,13 @@ class ReviewRepository:
                 and_(ReviewLike.review_id == Review.id, ReviewLike.user_id == user_id),
                 isouter=True,
             )
-            .filter(
-                Users.id == user_id,
-                Review.bakery_id == bakery_id,
-                Review.id > cursor_id,
-            )
-            .order_by(Review.created_at.desc())
-            .limit(page_size)
+            .filter(*filters)
+            .order_by(Review.id.desc())
+            .limit(page_size + 1)
         )
 
         res = self.db.execute(stmt).mappings().all()
+        has_next = len(res) > page_size
 
         return [
             MyBakeryReview(
@@ -55,8 +65,8 @@ class ReviewRepository:
                 review_rating=r.rating,
                 review_like_count=r.like_count,
             )
-            for r in res
-        ]
+            for r in res[:page_size]
+        ], has_next
 
     async def get_my_review_photos_by_bakery_id(self, review_ids: List[int]):
         """리뷰 내 사진 조회하는 쿼리."""
@@ -83,14 +93,27 @@ class ReviewRepository:
         self,
         user_id: int,
         bakery_id: int,
-        cursor_id: int,
+        cursor_value: str,
         sort_by: str,
         direction: str,
         page_size: int,
     ):
         """리뷰 주요데이터 조회하는 쿼리."""
 
+        # 정렬할 필드 추출 (Review.like_count 이런식)
         sort_column = getattr(Review, sort_by)
+        # sort_value:review_id 형태의 요청 파라미터를 조건절에 들어갈 수 있는 형태로 파싱
+        sort_value, cursor_id = parse_cursor_value(cursor_value, sort_by)
+        cursor_filter = build_cursor_filter(
+            sort_column, sort_value, cursor_id, direction
+        )
+        order_by = build_order_by(sort_column, direction)
+
+        print("cursor_filter ------> ", cursor_filter)
+
+        filters = [Review.bakery_id == bakery_id]
+        if cursor_filter is not None:
+            filters.append(cursor_filter)
 
         stmt = (
             select(
@@ -100,6 +123,7 @@ class ReviewRepository:
                 Review.id,
                 Review.content,
                 Review.rating,
+                Review.created_at,
                 Review.like_count,
                 ReviewLike.user_id,
             )
@@ -111,29 +135,81 @@ class ReviewRepository:
                 and_(ReviewLike.review_id == Review.id, ReviewLike.user_id == user_id),
                 isouter=True,
             )
-            .filter(
-                Review.bakery_id == bakery_id,
-                Review.id > cursor_id,
-            )
+            .filter(*filters)
+            .order_by(*order_by)
+            .limit(page_size + 1)
         )
 
-        if direction == "desc":
-            stmt = stmt.order_by(desc(sort_column)).limit(page_size)
-        else:
-            stmt = stmt.order_by(asc(sort_column)).limit(page_size)
-
         res = self.db.execute(stmt).mappings().all()
+        has_next = len(res) > page_size
 
-        return [
-            BakeryReview(
-                avg_rating=r.avg_rating,
-                review_id=r.id,
-                user_name=r.name,
-                profile_img=r.profile_img,
-                is_like=True if r.user_id else False,
-                review_content=r.content,
-                review_rating=r.rating,
-                review_like_count=r.like_count,
+        return (
+            [
+                BakeryReview(
+                    avg_rating=r.avg_rating,
+                    review_id=r.id,
+                    user_name=r.name,
+                    profile_img=r.profile_img,
+                    is_like=bool(r.user_id),
+                    review_content=r.content,
+                    review_rating=r.rating,
+                    review_like_count=r.like_count,
+                    review_created_at=r.created_at,
+                )
+                for r in res[:page_size]
+            ],
+            has_next,
+        )
+
+    async def get_today_review(self, user_id: int, bakery_id: int):
+        """오늘 작성한 리뷰 있는 지 조회하는 쿼리."""
+
+        review = (
+            self.db.query(Review.id)
+            .filter(
+                Review.user_id == user_id,
+                Review.bakery_id == bakery_id,
+                Review.created_at >= get_today_start(),
+                Review.created_at <= get_today_end(),
             )
-            for r in res
-        ]
+            .first()
+        )
+
+        return review
+
+    async def insert_review_infos(
+        self,
+        bakery_id: int,
+        rating: float,
+        content: str,
+        is_private: bool,
+        user_id: int,
+    ):
+        """리뷰 정보 insert하는 쿼리"""
+
+        try:
+            review_info = Review(
+                bakery_id=bakery_id,
+                rating=rating,
+                content=content,
+                is_private=is_private,
+                user_id=user_id,
+            )
+
+            self.db.add(review_info)
+            self.db.flush()
+            return review_info.id
+
+        except Exception as e:
+            raise UnknownError(detail=str(e))
+
+    # async def insert_review_menus(
+    #     self,
+    #     review_id :int,
+    #     consumed_menus:dict
+    # ):
+    #     try:
+
+    async def bucket_insert_review_imgs(self, bakery_id: int, filenames: List[str]):
+        """리뷰 이미지 한 번에 저장하는 쿼리."""
+        pass

--- a/app/schema/common.py
+++ b/app/schema/common.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -8,14 +10,10 @@ class AreaCode(BaseModel):
     area_name: str = Field(..., description="상권지역 이름")
 
 
-class Cursor(BaseModel):
-    """커서 모델."""
-
-    before: int = Field(default=0, description="이전 cursor_id")
-    after: int = Field(default=0, description="다음 페이지 조회를 위한 cursor_id")
-
-
 class Paging(BaseModel):
     """페이징 모델."""
 
-    cursor: Cursor = Field(..., description="이전/다음 페이징을 위한 cursor_id 객체.")
+    next_cursor: Optional[str] = Field(
+        default=None, description="다음 cursur_value에 위치할 데이터"
+    )
+    has_next: bool = Field(default=False, description="다음 페이지 유무")

--- a/app/schema/review.py
+++ b/app/schema/review.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
@@ -38,6 +39,7 @@ class BakeryReview(BaseModel):
     review_content: str = Field(..., description="작성한 리뷰 내용")
     review_rating: float = Field(..., description="별점")
     review_like_count: int = Field(default=0, description="리뷰 좋아요개수")
+    review_created_at: datetime = Field(..., description="리뷰 작성날짜.")
     review_menus: Optional[List[ReviewMenu]] = Field(
         default=[], description="리뷰한 메뉴"
     )
@@ -48,4 +50,9 @@ class BakeryReview(BaseModel):
 
 class BakeryReviewReponseDTO(BaseModel):
     items: List[BakeryReview] = Field(default=[], description="조회된 리뷰 데이터.")
+    paging: Paging = Field(..., description="페이징 정보")
+
+
+class BakeryMyReviewReponseDTO(BaseModel):
+    items: List[MyBakeryReview] = Field(default=[], description="조회된 리뷰 데이터.")
     paging: Paging = Field(..., description="페이징 정보")

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -11,7 +11,7 @@ from app.schema.bakery import (
     LoadMoreBakeryResponseDTO,
 )
 from app.schema.common import Cursor, Paging
-from app.utils.converter import convert_timezone_now
+from app.utils.date import get_now_by_timezone
 from app.utils.parser import parse_comma_to_list
 from app.utils.validator import validate_area_code
 
@@ -43,7 +43,7 @@ class BakeryService:
         validate_area_code(area_codes=area_codes)
 
         # 오늘 요일
-        target_day_of_week = convert_timezone_now().weekday()
+        target_day_of_week = get_now_by_timezone().weekday()
 
         # 유저 취향 + 지역 기반으로 빵집 조회
         return await BakeryRepository(self.db).get_bakeries_by_preference(
@@ -62,7 +62,7 @@ class BakeryService:
         # 지역코드 유효성 체크
         validate_area_code(area_codes=area_codes)
         # 오늘 요일
-        target_day_of_week = convert_timezone_now().weekday()
+        target_day_of_week = get_now_by_timezone().weekday()
 
         # 베이커리 정보 조회
         bakery_repo = BakeryRepository(db=self.db)
@@ -108,7 +108,7 @@ class BakeryService:
         # 지역코드 유효성 체크
         validate_area_code(area_codes=area_codes)
 
-        target_day_of_week = convert_timezone_now().weekday()
+        target_day_of_week = get_now_by_timezone().weekday()
 
         return await BakeryRepository(self.db).get_bakery_by_area(
             area_codes, target_day_of_week
@@ -123,7 +123,7 @@ class BakeryService:
         # 지역코드 유효성 체크
         validate_area_code(area_codes=area_codes)
 
-        target_day_of_week = convert_timezone_now().weekday()
+        target_day_of_week = get_now_by_timezone().weekday()
 
         bakery_repo = BakeryRepository(self.db)
 
@@ -164,7 +164,7 @@ class BakeryService:
         """베이커리 상세 조회하는 비즈니스 로직."""
 
         bakery_repo = BakeryRepository(db=self.db)
-        target_day_of_week = convert_timezone_now().weekday()
+        target_day_of_week = get_now_by_timezone().weekday()
 
         # 1. 베이커리 정보 가져오기
         bakery = await bakery_repo.get_bakery_detail(

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -10,7 +10,8 @@ from app.schema.bakery import (
     LoadMoreBakery,
     LoadMoreBakeryResponseDTO,
 )
-from app.schema.common import Cursor, Paging
+from app.schema.common import Paging
+from app.utils.converter import to_cursor_str
 from app.utils.date import get_now_by_timezone
 from app.utils.parser import parse_comma_to_list
 from app.utils.validator import validate_area_code
@@ -53,7 +54,7 @@ class BakeryService:
         )
 
     async def get_more_bakeries_by_preference(
-        self, cursor_id: int, page_size: int, area_code: str, user_id: int
+        self, cursor_value: str, page_size: int, area_code: str, user_id: int
     ):
         """(더보기) 유저의 취향이 반영된 빵집 조회하는 비즈니스 로직."""
 
@@ -66,8 +67,8 @@ class BakeryService:
 
         # 베이커리 정보 조회
         bakery_repo = BakeryRepository(db=self.db)
-        bakeries = await bakery_repo.get_more_bakeries_by_preference(
-            cursor_id=cursor_id,
+        bakeries, has_next = await bakery_repo.get_more_bakeries_by_preference(
+            cursor_value=cursor_value,
             page_size=page_size,
             area_codes=area_codes,
             user_id=user_id,
@@ -78,12 +79,7 @@ class BakeryService:
         if not bakeries:
             return LoadMoreBakeryResponseDTO(
                 items=[],
-                paging=Paging(
-                    cursor=Cursor(
-                        before=cursor_id,
-                        after=-1,  # 다음 페이지 없을 때,
-                    )
-                ),
+                paging=Paging(next_cursor=None, has_next=False),
             )
 
         # 베이커리 시그니처 메뉴 정보 조회
@@ -97,7 +93,7 @@ class BakeryService:
         return LoadMoreBakeryResponseDTO(
             items=bakery_infos,
             paging=Paging(
-                cursor=Cursor(before=cursor_id, after=bakeries[-1].bakery_id)
+                next_cursor=to_cursor_str(bakeries[-1].bakery_id), has_next=has_next
             ),
         )
 
@@ -115,7 +111,7 @@ class BakeryService:
         )
 
     async def get_hot_bakeries(
-        self, cursor_id: int, page_size: int, area_code: str
+        self, cursor_value: str, page_size: int, area_code: str
     ) -> LoadMoreBakeryResponseDTO:
         """(더보기용) hot한 빵집 조회하는 비즈니스 로직."""
 
@@ -128,8 +124,8 @@ class BakeryService:
         bakery_repo = BakeryRepository(self.db)
 
         # 빵집 정보
-        bakeries = await bakery_repo.get_more_hot_bakeries(
-            cursor_id=cursor_id,
+        bakeries, has_next = await bakery_repo.get_more_hot_bakeries(
+            cursor_value=cursor_value,
             area_codes=area_codes,
             target_day_of_week=target_day_of_week,
             page_size=page_size,
@@ -138,12 +134,7 @@ class BakeryService:
         if not bakeries:
             return LoadMoreBakeryResponseDTO(
                 items=[],
-                paging=Paging(
-                    cursor=Cursor(
-                        before=cursor_id,
-                        after=-1,  # 다음 페이지 없을 때,
-                    )
-                ),
+                paging=Paging(next_cursor=None, has_next=False),
             )
 
         # 빵 시그니처 메뉴 정보
@@ -156,7 +147,7 @@ class BakeryService:
         return LoadMoreBakeryResponseDTO(
             items=bakery_infos,
             paging=Paging(
-                cursor=Cursor(before=cursor_id, after=bakeries[-1].bakery_id)
+                next_cursor=to_cursor_str(bakeries[-1].bakery_id), has_next=has_next
             ),
         )
 

--- a/app/services/review_service.py
+++ b/app/services/review_service.py
@@ -1,17 +1,26 @@
+import json
 from collections import defaultdict
+from typing import List, Optional
 
+from fastapi import File, UploadFile
 from sqlalchemy.orm.session import Session
 
+from app.core.exception import DailyReviewLimitExceededExecption
 from app.repositories.review_repo import ReviewRepository
-from app.schema.common import Cursor, Paging
+from app.schema.common import Paging
 from app.schema.review import (
+    BakeryMyReviewReponseDTO,
     BakeryReview,
     BakeryReviewReponseDTO,
     MyBakeryReview,
     ReviewMenu,
     ReviewPhoto,
 )
+from app.utils.converter import convert_img_to_webp, to_cursor_str
+from app.utils.pagination import build_cursor
 from app.utils.parser import build_sort_clause
+from app.utils.upload import upload_multiple_to_supabase_storage
+from app.utils.validator import upload_image_file_validation
 
 
 class Review:
@@ -22,7 +31,7 @@ class Review:
         self,
         user_id: int,
         bakery_id: int,
-        cursor_id: int,
+        cursor_value: str,
         page_size: int,
         sort_clause: str,
     ):
@@ -32,10 +41,10 @@ class Review:
         sort_by, direction = build_sort_clause(sort_clause=sort_clause)
 
         # 1. 리뷰 주요 데이터 조회
-        review_infos = await review_repo.get_reviews_by_bakery_id(
+        review_infos, has_next = await review_repo.get_reviews_by_bakery_id(
             user_id=user_id,
             bakery_id=bakery_id,
-            cursor_id=cursor_id,
+            cursor_value=cursor_value,
             sort_by=sort_by,
             direction=direction,
             page_size=page_size,
@@ -60,6 +69,11 @@ class Review:
             for r in review_menus:
                 review_menu_maps[r.review_id].append(ReviewMenu(menu_name=r.name))
 
+            # 4. next_cursor
+            sort_value = getattr(review_infos[-1], f"review_{sort_by}")
+            review_id = review_infos[-1].review_id
+            next_cursor = build_cursor(sort_value, review_id)
+
             return BakeryReviewReponseDTO(
                 items=[
                     BakeryReview(
@@ -69,25 +83,25 @@ class Review:
                     )
                     for r in review_infos
                 ],
-                paging=Paging(cursor=Cursor(before=cursor_id, after=revies_ids[-1])),
+                paging=Paging(next_cursor=next_cursor, has_next=has_next),
             )
 
         return BakeryReviewReponseDTO(
             items=[],
-            paging=Paging(cursor=Cursor(before=cursor_id, after=-1)),
+            paging=Paging(next_cursor=None, has_next=False),
         )
 
     async def get_my_reviews_by_bakery_id(
-        self, bakery_id: int, user_id: int, cursor_id: int, page_size: int
+        self, bakery_id: int, user_id: int, cursor_value: str, page_size: int
     ):
         """특정 베이커리에 내 리뷰 조회하는 비즈니스 로직."""
         review_repo = ReviewRepository(db=self.db)
 
         # 1. 리뷰 주요 데이터 조회
-        review_infos = await review_repo.get_my_reviews_by_bakery_id(
+        review_infos, has_next = await review_repo.get_my_reviews_by_bakery_id(
             bakery_id=bakery_id,
             user_id=user_id,
-            cursor_id=cursor_id,
+            cursor_value=cursor_value,
             page_size=page_size,
         )
 
@@ -110,13 +124,25 @@ class Review:
             for r in review_menus:
                 review_menu_maps[r.review_id].append(ReviewMenu(menu_name=r.name))
 
-            return [
-                MyBakeryReview(
-                    **r.model_dump(exclude={"review_photos", "review_menus"}),
-                    review_photos=photo_maps.get(r.review_id, []),
-                    review_menus=review_menu_maps.get(r.review_id, []),
-                )
-                for r in review_infos
-            ]
+            return BakeryMyReviewReponseDTO(
+                items=[
+                    MyBakeryReview(
+                        **r.model_dump(exclude={"review_photos", "review_menus"}),
+                        review_photos=photo_maps.get(r.review_id, []),
+                        review_menus=review_menu_maps.get(r.review_id, []),
+                    )
+                    for r in review_infos
+                ],
+                paging=Paging(
+                    next_cursor=to_cursor_str(review_infos[-1].review_id),
+                    has_next=has_next,
+                ),
+            )
 
-        return []
+        return BakeryMyReviewReponseDTO(
+            items=[],
+            paging=Paging(
+                next_cursor=None,
+                has_next=False,
+            ),
+        )

--- a/app/services/tour_service.py
+++ b/app/services/tour_service.py
@@ -13,10 +13,10 @@ from app.core.exception import UnknownError
 from app.schema.tour import EventPopupResponseDTO, TourResponseDTO
 from app.utils.converter import (
     area_to_sigungu,
-    convert_timezone_now,
     replace_space_with_plus,
     transform_tour_response,
 )
+from app.utils.date import get_now_by_timezone
 from app.utils.parser import parse_comma_to_list
 
 config = Configs()
@@ -51,7 +51,7 @@ class TourService:
         """오늘 진행하는 행사만 반환하는 메소드."""
 
         filtered_events = []
-        today = convert_timezone_now().date()
+        today = get_now_by_timezone().date()
 
         for e in events:
             start_date = datetime.strptime(e.get("eventstartdate"), "%Y%m%d")

--- a/app/utils/converter.py
+++ b/app/utils/converter.py
@@ -1,8 +1,14 @@
+import uuid
 from datetime import datetime, time
-from typing import Optional
+from io import BytesIO
+from typing import List, Optional
 from zoneinfo import ZoneInfo
 
-from app.core.exception import UnknownError
+from fastapi import UploadFile
+from PIL import Image
+
+from app.core.exception import ConvertImageError, UnknownError
+from app.utils.date import get_now_by_timezone
 from app.utils.parser import parse_comma_to_list
 
 AREA_TO_SIGUNGU = {
@@ -24,12 +30,6 @@ AREA_TO_SIGUNGU = {
 read_more_link_domain = (
     "https://search.daum.net/search?w=tot&DA=YZR&t__nil_searchbox=btn&q="
 )
-
-
-def convert_timezone_now():
-    """국가에 맞게 타임존 반영해서 오늘 날짜 반환하는 메소드."""
-
-    return datetime.now(ZoneInfo("Asia/Seoul"))
 
 
 def user_info_to_id(user_info) -> int:
@@ -74,7 +74,7 @@ def operating_hours_to_open_status(
     open_time: Optional[time] = None,
 ):
     """영업시간 데이터 기반으로 영업상태 ENUM 반환하는 메소드."""
-    now = convert_timezone_now().time()
+    now = get_now_by_timezone().time()
 
     if not is_opened:
         # 휴무일

--- a/app/utils/date.py
+++ b/app/utils/date.py
@@ -1,0 +1,24 @@
+from datetime import datetime, time
+from zoneinfo import ZoneInfo
+
+
+# TODO - 국가별 타임존 처리하는 거 수정 필요.
+def get_now_by_timezone(tz: str = "Asia/Seoul"):
+    """국가에 맞게 타임존 반영해서 오늘 날짜 반환하는 메소드."""
+
+    return datetime.now(ZoneInfo(tz))
+
+
+# 이거는 UTC 기준
+def get_today_start():
+    """하루의 시작시간을 반환하는 메소드."""
+
+    today = datetime.today()
+    return datetime.combine(today.date(), time.min)
+
+
+def get_today_end():
+    """하루의 끝 시간을 반환하는 메소드."""
+
+    today = datetime.today()
+    return datetime.combine(today.date(), time.max)

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+from sqlalchemy import and_, asc, desc, or_
+
+from app.core.exception import InvalidSortParameterError
+from app.model.review import Review
+
+
+def parse_value(value_str: str, sort_by: str):
+    """커서 문자열을 정렬 필드에 맞는 타입으로 변환하는 메소드."""
+
+    if sort_by == "created_at":
+        return datetime.fromisoformat(value_str)
+    elif sort_by in {"rating", "like_count"}:
+        return float(value_str)
+    else:
+        raise ValueError(f"Unsupported sort_by: {sort_by}")
+
+
+def parse_cursor_value(cursor_value: str, sort_by: str):
+    """sort_value:review_id 형태의 커서를 파싱하여 비교 가능한 값으로 분리하는 메소드."""
+
+    if cursor_value == "0:0":
+        return None, None
+    try:
+        sort_value_str, id_str = cursor_value.split(":")
+        return parse_value(sort_value_str, sort_by), int(id_str)
+    except Exception:
+        raise InvalidSortParameterError()
+
+
+def build_cursor_filter(sort_column, sort_value, cursor_id, direction):
+    """커서 기반으로 WHERE 조건을 생성하는 메소드."""
+
+    if sort_value is None or cursor_id is None:
+        return None
+    if direction == "desc":
+        return or_(
+            sort_column < sort_value,
+            and_(sort_column == sort_value, Review.id > cursor_id),
+        )
+    else:
+        return or_(
+            sort_column > sort_value,
+            and_(sort_column == sort_value, Review.id > cursor_id),
+        )
+
+
+def build_order_by(sort_column, direction):
+    """정렬 컬럼과 id를 기준으로 안정적인 ORDER BY 리스트 생성하는 메소드."""
+
+    if direction == "desc":
+        return [desc(sort_column), asc(Review.id)]
+    else:
+        return [asc(sort_column), asc(Review.id)]
+
+
+def build_cursor(sort_value, review_id):
+    """다음 페이지 요청 시 넘겨줄 커서 문자열 생성하는 메소드."""
+
+    return f"{sort_value}:{review_id}"


### PR DESCRIPTION
## 🚀 Description
### 1. 커서 페이징 구조를 다음과 같이 전면 개선
- 기존 ID 기반 커서 → 정렬필드 + 고유 ID 복합 커서 구조로 변경
- 정렬 기준 필드(like_count, rating, created_at) 추가 대응
- 요청 파라미터 cursor_id: int → cursor_value: str 변경
- 응답 페이징 객체 단순화 및 has_next 필드 추가
- ORM 쿼리 개선: ORDER BY와 WHERE 절에 정렬 필드 + ID 동적 조합 적용

### 2. 베이커리 메뉴 중 "기타메뉴" 대응

## 📸 Screenshot
```bash
// 변경 전
"paging": {
  "cursor": {
    "before": 0,
    "after": 15
  }
}

// 변경 후
"paging": {
  "next_cursor": "4.5:1012",
  "has_next": true
}
```
## 📢 Notes

- 다음 페이지 조회 시에는 응답의 paging.next_cursor 값을 그대로 사용해주세요.
- has_next는 다음 페이지 존재 여부를 명시하는 boolean 필드입니다.