### PR TITLE
찜한 빵집 조회하는 API | 해당 베이커리 리뷰 작성여부 체크하는 API | refactoring | fix

### DIFF
--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -23,6 +23,7 @@ from app.schema.bakery import (
     LoadMoreBakeryResponseDTO,
     RecommendBakery,
     SimpleBakeryMenu,
+    WrittenReview,
 )
 from app.schema.review import BakeryMyReviewReponseDTO, BakeryReviewReponseDTO
 from app.services.bakery_service import BakeryService
@@ -150,6 +151,23 @@ async def get_visited_bakery(
     return BaseResponse(
         data=await BakeryService(db=db).get_visited_bakery(
             user_id=user_id, cursor_value=cursor_value, page_size=page_size
+        )
+    )
+
+
+@router.get(
+    "/{bakery_id}/review/eligibility",
+    response_model=BaseResponse[WrittenReview],
+    responses=ERROR_UNKNOWN,
+)
+async def check_is_eligible_to_write_review(
+    bakery_id: int, user_id: int = Depends(get_user_id), db=Depends(get_db)
+):
+    """리뷰 작성 가능여부 체크하는 API."""
+
+    return BaseResponse(
+        data=await BakeryService(db=db).check_is_eligible_to_write_review(
+            bakery_id=bakery_id, user_id=user_id
         )
     )
 

--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -19,6 +19,7 @@ from app.core.exception import (
 from app.schema.bakery import (
     BakeryDetailResponseDTO,
     BakeryLikeResponseDTO,
+    GuDongMenuBakeryResponseDTO,
     LoadMoreBakeryResponseDTO,
     RecommendBakery,
     SimpleBakeryMenu,
@@ -316,3 +317,26 @@ async def dislike_bakery(
     await BakeryService(db=db).dislike_bakery(user_id=user_id, bakery_id=bakery_id)
 
     return BaseResponse(data=BakeryLikeResponseDTO(is_like=False, bakery_id=bakery_id))
+
+
+@router.get(
+    "/{bakery_id}/like",
+    response_model=BaseResponse[GuDongMenuBakeryResponseDTO],
+    responses=ERROR_UNKNOWN,
+)
+async def get_like_bakery(
+    cursor_value: str = Query(
+        default="0",
+        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
+    ),
+    page_size: int = Query(default=5),
+    user_id: int = Depends(get_user_id),
+    db=Depends(get_db),
+):
+    """내가 찜한 빵집 조회하는 API."""
+
+    return BaseResponse(
+        data=await BakeryService(db=db).get_like_bakery(
+            user_id=user_id, cursor_value=cursor_value, page_size=page_size
+        )
+    )

--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -208,9 +208,9 @@ async def get_bakery_menus(
 async def get_reviews_by_bakery_id(
     bakery_id: int,
     cursor_value: str = Query(
-        default="0:0",
+        default="0||0",
         description="""
-    처음엔 0:0으로 넘겨주고, 
+    처음엔 0||0으로 넘겨주고, 
     그 다음부턴 response 내 next_cursor값을 입력해주세요.
         """,
     ),

--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -336,7 +336,7 @@ async def get_like_bakery(
     """내가 찜한 빵집 조회하는 API."""
 
     return BaseResponse(
-        data=await BakeryService(db=db).get_like_bakery(
+        data=await BakeryService(db=db).get_like_bakeries(
             user_id=user_id, cursor_value=cursor_value, page_size=page_size
         )
     )

--- a/app/model/review.py
+++ b/app/model/review.py
@@ -21,6 +21,9 @@ class Review(Base, DateTimeMixin):
         comment="나만보기 여부 (True : 나만공개 / False : 전체공개)",
     )
     like_count = Column(Integer, nullable=False, default=0, comment="좋아요 개수")
+    day_of_week = Column(
+        Integer, nullable=False, default=0, comment="요일 : 월 0 ~ 일 6"
+    )
 
 
 class ReviewPhoto(Base):

--- a/app/repositories/bakery_repo.py
+++ b/app/repositories/bakery_repo.py
@@ -23,10 +23,10 @@ from app.schema.bakery import (
     BakeryDetail,
     BakeryDetailResponseDTO,
     BakeryOperatingHour,
+    GuDongMenuBakery,
     LoadMoreBakery,
     RecommendBakery,
     SimpleBakeryMenu,
-    VisitedBakery,
 )
 from app.utils.converter import operating_hours_to_open_status
 
@@ -594,7 +594,7 @@ class BakeryRepository:
             has_next = len(res) > page_size
 
             return [
-                VisitedBakery(
+                GuDongMenuBakery(
                     bakery_id=r.id,
                     bakery_name=r.name,
                     avg_rating=r.avg_rating,
@@ -677,4 +677,71 @@ class BakeryRepository:
                 self.db.commit()
         except Exception as e:
             self.db.rollback()
+            raise UnknownException(detail=str(e))
+
+    async def get_like_bakery(
+        self, user_id: int, target_day_of_week: int, cursor_value: str, page_size: int
+    ):
+        try:
+
+            stmt = (
+                select(
+                    Bakery.id,
+                    Bakery.name,
+                    Bakery.avg_rating,
+                    Bakery.review_count,
+                    Bakery.gu,
+                    Bakery.dong,
+                    Bakery.thumbnail,
+                    OperatingHour.close_time,
+                    OperatingHour.open_time,
+                    OperatingHour.is_opened,
+                )
+                .select_from(Bakery)
+                .join(
+                    UserBakeryLikes,
+                    and_(
+                        UserBakeryLikes.bakery_id == Bakery.id,
+                        UserBakeryLikes.user_id == user_id,
+                    ),
+                )
+                .join(
+                    OperatingHour,
+                    and_(
+                        OperatingHour.bakery_id == Bakery.id,
+                        OperatingHour.day_of_week == target_day_of_week,
+                    ),
+                    isouter=True,
+                )
+                .order_by(desc(Bakery.id))
+                .distinct(Bakery.id)
+                .limit(page_size + 1)
+            )
+
+            if cursor_value != "0":
+                stmt = stmt.where(Bakery.id > int(cursor_value))
+
+            res = self.db.execute(stmt).all()
+            has_next = len(res) > page_size
+
+            return [
+                GuDongMenuBakery(
+                    bakery_id=r.id,
+                    bakery_name=r.name,
+                    avg_rating=r.avg_rating,
+                    review_count=r.review_count,
+                    gu=r.gu,
+                    dong=r.dong,
+                    img_url=r.thumbnail,
+                    is_like=True,
+                    open_status=operating_hours_to_open_status(
+                        is_opened=r.is_opened,
+                        close_time=r.close_time,
+                        open_time=r.open_time,
+                    ),
+                )
+                for r in res
+            ], has_next
+
+        except Exception as e:
             raise UnknownException(detail=str(e))

--- a/app/repositories/bakery_repo.py
+++ b/app/repositories/bakery_repo.py
@@ -679,11 +679,12 @@ class BakeryRepository:
             self.db.rollback()
             raise UnknownException(detail=str(e))
 
-    async def get_like_bakery(
+    async def get_like_bakeries(
         self, user_id: int, target_day_of_week: int, cursor_value: str, page_size: int
     ):
-        try:
+        """찜한 베이커리 조회하는 쿼리."""
 
+        try:
             stmt = (
                 select(
                     Bakery.id,

--- a/app/repositories/bakery_repo.py
+++ b/app/repositories/bakery_repo.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from sqlalchemy import and_, desc, select
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.session import Session
@@ -614,6 +616,26 @@ class BakeryRepository:
 
         except Exception as e:
             raise UnknownException(str(e))
+
+    async def get_reviews_written_today(
+        self, user_id: int, bakery_id: int, start_time: datetime, end_time: datetime
+    ):
+        """해당 베이커리에 오늘 유저가 작성한 리뷰 조회하는 쿼리."""
+        try:
+            written_review = (
+                self.db.query(Review)
+                .filter(
+                    Review.user_id == user_id,
+                    Review.bakery_id == bakery_id,
+                    start_time <= Review.created_at,
+                    end_time >= Review.created_at,
+                )
+                .first()
+            )
+
+            return True if written_review else False
+        except Exception as e:
+            raise UnknownException(detail=str(e))
 
     async def check_already_liked_bakery(self, user_id: int, bakery_id: int):
         try:

--- a/app/repositories/review_repo.py
+++ b/app/repositories/review_repo.py
@@ -212,6 +212,7 @@ class ReviewRepository:
         content: str,
         is_private: bool,
         user_id: int,
+        target_day_of_week: int,
     ):
         """리뷰 정보 insert하는 쿼리"""
 
@@ -224,6 +225,7 @@ class ReviewRepository:
                 user_id=user_id,
                 like_count=0,
                 visit_date=get_now_by_timezone(tz="UTC"),
+                day_of_week=target_day_of_week,
             )
 
             self.db.add(review_info)

--- a/app/repositories/review_repo.py
+++ b/app/repositories/review_repo.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session
 
 from app.core.exception import (
@@ -115,7 +115,15 @@ class ReviewRepository:
         )
         order_by = build_order_by(sort_column, direction)
 
-        filters = [Review.bakery_id == bakery_id]
+        filters = [
+            and_(
+                Review.bakery_id == bakery_id,
+                or_(
+                    Review.is_private == False,
+                    and_(Review.is_private == True, Review.user_id == user_id),
+                ),
+            )
+        ]
         if cursor_filter is not None:
             filters.append(cursor_filter)
 

--- a/app/schema/bakery.py
+++ b/app/schema/bakery.py
@@ -130,6 +130,10 @@ class GuDongMenuBakeryResponseDTO(BaseModel):
     paging: Paging
 
 
+class WrittenReview(BaseModel):
+    is_eligible: bool = Field(..., description="오늘 리뷰 작성가능 여부.")
+
+
 class BakeryLikeResponseDTO(BaseModel):
     is_like: bool = Field(..., description="찜여부")
     bakery_id: int = Field(..., description="빵집 id")

--- a/app/schema/bakery.py
+++ b/app/schema/bakery.py
@@ -115,7 +115,7 @@ class SimpleBakeryMenu(BaseModel):
     is_signature: bool = Field(..., description="대표메뉴 여부")
 
 
-class VisitedBakery(CommonBakery):
+class GuDongMenuBakery(CommonBakery):
     """방문한 빵집"""
 
     gu: str = Field(..., description="베이커리 자치구")
@@ -125,8 +125,8 @@ class VisitedBakery(CommonBakery):
     )
 
 
-class VisitedBakeryResponseDTO(BaseModel):
-    items: List[VisitedBakery]
+class GuDongMenuBakeryResponseDTO(BaseModel):
+    items: List[GuDongMenuBakery]
     paging: Paging
 
 

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -6,10 +6,11 @@ from app.schema.bakery import (
     BakeryDetailResponseDTO,
     GuDongMenuBakeryResponseDTO,
     LoadMoreBakeryResponseDTO,
+    WrittenReview,
 )
 from app.schema.common import Paging
 from app.utils.converter import merge_menus_with_bakeries, to_cursor_str
-from app.utils.date import get_now_by_timezone
+from app.utils.date import get_now_by_timezone, get_today_end, get_today_start
 from app.utils.parser import parse_comma_to_list
 from app.utils.validator import validate_area_code
 
@@ -219,6 +220,21 @@ class BakeryService:
                 has_next=has_next,
             ),
         )
+
+    async def check_is_eligible_to_write_review(self, bakery_id: int, user_id: int):
+        """리뷰를 작성해도 되는지 체크하는 비즈니스 로직."""
+
+        start_time = get_today_start()
+        end_time = get_today_end()
+
+        written_review = await BakeryRepository(db=self.db).get_reviews_written_today(
+            user_id=user_id,
+            bakery_id=bakery_id,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        return WrittenReview(is_eligible=False if written_review else True)
 
     async def like_bakery(self, user_id: int, bakery_id: int):
         """베이커리 찜하는 비즈니스 로직."""

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -243,14 +243,14 @@ class BakeryService:
         # 2. 해당 베이커리 찜 삭제
         await bakery_repo.dislike_bakery(user_id=user_id, bakery_id=bakery_id)
 
-    async def get_like_bakery(self, user_id: int, cursor_value: str, page_size: int):
+    async def get_like_bakeries(self, user_id: int, cursor_value: str, page_size: int):
         """내가 찜한 빵집 조회하는 비즈니스 로직."""
 
         bakery_repo = BakeryRepository(db=self.db)
 
         # 1. 베이커리 조회
         target_day_of_week = get_now_by_timezone().weekday()
-        bakeries, has_next = await bakery_repo.get_like_bakery(
+        bakeries, has_next = await bakery_repo.get_like_bakeries(
             user_id=user_id,
             target_day_of_week=target_day_of_week,
             cursor_value=cursor_value,

--- a/app/services/review_service.py
+++ b/app/services/review_service.py
@@ -17,6 +17,7 @@ from app.schema.review import (
     ReviewPhoto,
 )
 from app.utils.converter import convert_img_to_webp, to_cursor_str
+from app.utils.date import get_now_by_timezone
 from app.utils.pagination import build_cursor
 from app.utils.parser import build_sort_clause
 from app.utils.upload import upload_multiple_to_supabase_storage
@@ -185,12 +186,14 @@ class Review:
             )
 
         # 4. 리뷰 데이터 insert
+        target_day_of_week = get_now_by_timezone().weekday()
         review_id = await review_repo.insert_review_infos(
             bakery_id=bakery_id,
             rating=rating,
             content=content,
             is_private=is_private,
             user_id=user_id,
+            target_day_of_week=target_day_of_week,
         )
         # 5. 리뷰 메뉴 insert
         await review_repo.bulk_insert_review_menus(

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -37,7 +37,7 @@ def build_cursor_filter(sort_column, sort_value, cursor_id, direction):
     if direction == "desc":
         return or_(
             sort_column < sort_value,
-            and_(sort_column == sort_value, Review.id > cursor_id),
+            and_(sort_column == sort_value, Review.id < cursor_id),
         )
     else:
         return or_(
@@ -52,7 +52,7 @@ def build_order_by(sort_column, direction):
     if direction == "desc":
         return [desc(sort_column), desc(Review.id)]
     else:
-        return [asc(sort_column), asc(Review.id)]
+        return [asc(sort_column), desc(Review.id)]
 
 
 def build_cursor(sort_value, review_id):

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -20,10 +20,10 @@ def parse_value(value_str: str, sort_by: str):
 def parse_cursor_value(cursor_value: str, sort_by: str):
     """sort_value:review_id 형태의 커서를 파싱하여 비교 가능한 값으로 분리하는 메소드."""
 
-    if cursor_value == "0:0":
+    if cursor_value == "0||0":
         return None, None
     try:
-        sort_value_str, id_str = cursor_value.split(":")
+        sort_value_str, id_str = cursor_value.split("||")
         return parse_value(sort_value_str, sort_by), int(id_str)
     except Exception:
         raise InvalidSortParameterException()
@@ -58,4 +58,4 @@ def build_order_by(sort_column, direction):
 def build_cursor(sort_value, review_id):
     """다음 페이지 요청 시 넘겨줄 커서 문자열 생성하는 메소드."""
 
-    return f"{sort_value}:{review_id}"
+    return f"{sort_value}||{review_id}"


### PR DESCRIPTION
## 🚀 Description
### 1. 찜한 빵집 조회하는 API ( 목록형 )

### 2. 해당 베이커리 리뷰 작성여부 체크하는 API

### 3. 리팩토링
- 정렬기준 있는 cursor_value 구분자 변경 ( ":" -> "||" )
  - 변경 이유는 CREATED_AT ( 날짜순 )으로 정렬할 때, 날짜 데이터 자체에 ":"가 포함되어 있어 cursor의 구분자 역할을 올바르게 수행 못함 
  - 그로인해 다음 페이지로 넘어가지를 못함 
- 메소드 명 좀 더 명시적으로 수정

### 4. 오류 수정
- 정렬방향 오류 수정

## 📸 Screenshot
### 변경 전 ":" 구분자로 인해 문제가 발생하는 케이스 
#### -> CREATED.DESC 정렬 시, created_at 데이터 자체에 ":"가 포함되어, cursor 구분자의 역할이 제대로 동작 안함.
<img width="402" height="102" alt="스크린샷 2025-07-30 오후 4 35 34" src="https://github.com/user-attachments/assets/4d290c32-6ea1-41a5-8893-44696fb4bbd7" />


### 변경 후의  구분자
<img width="434" height="102" alt="스크린샷 2025-07-30 오후 4 34 31" src="https://github.com/user-attachments/assets/555de47a-d5a7-4fab-8648-e4d7db60fd39" />

## 📢 Notes