### PR TITLE
페이징 구조 변경 | 검색 시 상권지역 ID값 | 베이커리 중복데이터 이슈 수정

### DIFF
--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -206,13 +206,7 @@ async def get_bakery_menus(
 )
 async def get_reviews_by_bakery_id(
     bakery_id: int,
-    cursor_value: str = Query(
-        default="0||0",
-        description="""
-    처음엔 0||0으로 넘겨주고, 
-    그 다음부턴 response 내 next_cursor값을 입력해주세요.
-        """,
-    ),
+    page_no: int = Query(default=1, description="페이지 번호"),
     page_size: int = Query(default=5),
     sort_clause: str = Query(
         default="LIKE_COUNT.DESC",
@@ -233,7 +227,7 @@ async def get_reviews_by_bakery_id(
         data=await Review(db=db).get_reviews_by_bakery_id(
             user_id=user_id,
             bakery_id=bakery_id,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
             sort_clause=sort_clause,
         )

--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -68,10 +68,7 @@ async def get_preference_bakery(
     area_code: str = Query(
         description="지역 코드 (쉼표로 여러 개 전달 가능, 예: '1, 2, 3')"
     ),
-    cursor_value: str = Query(
-        default="0",
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
-    ),
+    page_no: int = Query(default=1, description="몇 번째 페이지"),
     page_size: int = Query(default=15),
     user_id=Depends(get_user_id),
     db=Depends(get_db),
@@ -80,7 +77,7 @@ async def get_preference_bakery(
 
     return BaseResponse(
         data=await BakeryService(db=db).get_more_bakeries_by_preference(
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
             area_code=area_code,
             user_id=user_id,

--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -140,18 +140,16 @@ async def get_hot_bakeries(
 
 @router.get("/visited")
 async def get_visited_bakery(
-    cursor_value: str = Query(
-        default="0",
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
-    ),
+    page_no: int = Query(default=1, description="페이지 번호"),
     page_size: int = Query(default=5),
     user_id: int = Depends(get_user_id),
     db=Depends(get_db),
 ):
+    """내가 방문한 빵집 조회하는 API."""
 
     return BaseResponse(
         data=await BakeryService(db=db).get_visited_bakery(
-            user_id=user_id, cursor_value=cursor_value, page_size=page_size
+            user_id=user_id, page_no=page_no, page_size=page_size
         )
     )
 

--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -68,7 +68,7 @@ async def get_preference_bakery(
     area_code: str = Query(
         description="지역 코드 (쉼표로 여러 개 전달 가능, 예: '1, 2, 3')"
     ),
-    page_no: int = Query(default=1, description="몇 번째 페이지"),
+    page_no: int = Query(default=1, description="페이지 번호"),
     page_size: int = Query(default=15),
     user_id=Depends(get_user_id),
     db=Depends(get_db),
@@ -121,10 +121,7 @@ async def get_hot_bakeries(
     area_code: str = Query(
         description="지역 코드 (쉼표로 여러 개 전달 가능, 예: '1, 2, 3')"
     ),
-    cursor_value: str = Query(
-        default="0",
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
-    ),
+    page_no: int = Query(default=1, description="페이지 번호"),
     page_size: int = Query(default=15),
     user_id: int = Depends(get_user_id),
     db=Depends(get_db),
@@ -135,7 +132,7 @@ async def get_hot_bakeries(
         data=await BakeryService(db=db).get_hot_bakeries(
             area_code=area_code,
             user_id=user_id,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
         )
     )

--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -333,10 +333,7 @@ async def dislike_bakery(
     responses=ERROR_UNKNOWN,
 )
 async def get_like_bakery(
-    cursor_value: str = Query(
-        default="0",
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
-    ),
+    page_no: int = Query(default=1, description="페이지 번호"),
     page_size: int = Query(default=5),
     user_id: int = Depends(get_user_id),
     db=Depends(get_db),
@@ -345,6 +342,6 @@ async def get_like_bakery(
 
     return BaseResponse(
         data=await BakeryService(db=db).get_like_bakeries(
-            user_id=user_id, cursor_value=cursor_value, page_size=page_size
+            user_id=user_id, page_no=page_no, page_size=page_size
         )
     )

--- a/app/api/bakery.py
+++ b/app/api/bakery.py
@@ -239,10 +239,7 @@ async def get_reviews_by_bakery_id(
 )
 async def get_my_bakery_review(
     bakery_id: int,
-    cursor_value: str = Query(
-        default=0,
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
-    ),
+    page_no: int = Query(default=1, description="페이지 번호"),
     page_size: int = Query(default=5),
     user_id=Depends(get_user_id),
     db=Depends(get_db),
@@ -253,7 +250,7 @@ async def get_my_bakery_review(
         data=await Review(db=db).get_my_reviews_by_bakery_id(
             bakery_id=bakery_id,
             user_id=user_id,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
         )
     )

--- a/app/api/search.py
+++ b/app/api/search.py
@@ -13,19 +13,18 @@ router = APIRouter(prefix="/search", tags=["search"])
 @router.get("/bakeries", response_model=BaseResponse[SearchBakeryResponseDTO])
 async def search_bakeries_by_keyword(
     keyword: str,
-    cursor_value: str = Query(
-        default="0",
-        description="처음엔 0을 입력하고, 다음 페이지부터는 응답에서 받은 paging.next_cursor 값을 사용해서 조회.",
-    ),
-    page_size: int = Query(default=5),
+    page_no: int = Query(default=1, description="페이지 번호"),
+    page_size: int = Query(default=20),
     user_id: int = Depends(get_user_id),
     db=Depends(get_db),
 ):
+    """검색어로 빵집 조회하는 API."""
+
     return BaseResponse(
         data=await SearchService(db=db).search_bakeries_by_keyword(
             keyword=keyword,
             user_id=user_id,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
         )
     )

--- a/app/repositories/bakery_repo.py
+++ b/app/repositories/bakery_repo.py
@@ -717,9 +717,11 @@ class BakeryRepository:
             raise UnknownException(detail=str(e))
 
     async def get_like_bakeries(
-        self, user_id: int, target_day_of_week: int, cursor_value: str, page_size: int
+        self, user_id: int, target_day_of_week: int, page_no: int, page_size: int
     ):
         """찜한 베이커리 조회하는 쿼리."""
+
+        limit, offset = convert_limit_and_offset(page_no=page_no, page_size=page_size)
 
         try:
             stmt = (
@@ -753,11 +755,9 @@ class BakeryRepository:
                 )
                 .order_by(desc(Bakery.id))
                 .distinct(Bakery.id)
-                .limit(page_size + 1)
+                .limit(limit)
+                .offset(offset)
             )
-
-            if cursor_value != "0":
-                stmt = stmt.where(Bakery.id > int(cursor_value))
 
             res = self.db.execute(stmt).all()
             has_next = len(res) > page_size

--- a/app/repositories/bakery_repo.py
+++ b/app/repositories/bakery_repo.py
@@ -556,9 +556,11 @@ class BakeryRepository:
             raise UnknownException(detail=str(e))
 
     async def get_visited_bakery(
-        self, user_id: int, target_day_of_week: int, cursor_value: str, page_size: int
+        self, user_id: int, target_day_of_week: int, page_no: int, page_size: int
     ):
         """방문한 빵집 (내가 리뷰 쓴 빵집 ) 조회하는 쿼리."""
+
+        limit, offset = convert_limit_and_offset(page_no=page_no, page_size=page_size)
 
         try:
             stmt = (
@@ -601,11 +603,9 @@ class BakeryRepository:
                 )
                 .order_by(desc(Bakery.id))
                 .distinct(Bakery.id)
-                .limit(page_size + 1)
+                .limit(limit)
+                .offset(offset)
             )
-
-            if cursor_value != "0":
-                stmt = stmt.where(Bakery.id > int(cursor_value))
 
             res = self.db.execute(stmt).all()
             has_next = len(res) > page_size

--- a/app/repositories/search_repo.py
+++ b/app/repositories/search_repo.py
@@ -64,6 +64,7 @@ class SearchRepository:
                         BakeryMenu.name.ilike(f"{keyword}%"),
                     )
                 )
+                .distinct(Bakery.id)
                 .order_by(desc(Bakery.id))
                 .limit(limit)
                 .offset(offset)

--- a/app/repositories/search_repo.py
+++ b/app/repositories/search_repo.py
@@ -6,6 +6,7 @@ from app.model.bakery import Bakery, BakeryMenu, BakeryPhoto, OperatingHour
 from app.model.users import UserBakeryLikes
 from app.schema.search import SearchBakery
 from app.utils.converter import operating_hours_to_open_status
+from app.utils.pagination import convert_limit_and_offset
 
 
 class SearchRepository:
@@ -17,21 +18,14 @@ class SearchRepository:
         keyword: str,
         user_id: int,
         target_day_of_week: int,
-        cursor_value: str,
+        page_no: int,
         page_size: int,
     ):
         """키워드로 베이커리 조회하는 쿼리."""
+
+        limit, offset = convert_limit_and_offset(page_no=page_no, page_size=page_size)
+
         try:
-            where_conditions = [
-                or_(
-                    Bakery.name.ilike(f"{keyword}%"),
-                    BakeryMenu.name.ilike(f"{keyword}%"),
-                )
-            ]
-
-            if cursor_value != "0":
-                where_conditions.append(Bakery.id < cursor_value)
-
             stmt = (
                 select(
                     Bakery.id,
@@ -63,9 +57,15 @@ class SearchRepository:
                     ),
                     isouter=True,
                 )
-                .where(and_(*where_conditions))
+                .where(
+                    or_(
+                        Bakery.name.ilike(f"{keyword}%"),
+                        BakeryMenu.name.ilike(f"{keyword}%"),
+                    )
+                )
                 .order_by(desc(Bakery.id))
-                .limit(page_size + 1)
+                .limit(limit)
+                .offset(offset)
             )
 
             res = self.db.execute(stmt).all()

--- a/app/repositories/search_repo.py
+++ b/app/repositories/search_repo.py
@@ -35,6 +35,7 @@ class SearchRepository:
                     Bakery.avg_rating,
                     Bakery.review_count,
                     Bakery.thumbnail,
+                    Bakery.commercial_area_id,
                     OperatingHour.is_opened,
                     OperatingHour.open_time,
                     OperatingHour.close_time,
@@ -80,6 +81,7 @@ class SearchRepository:
                     gu=r.gu,
                     dong=r.dong,
                     img_url=r.thumbnail,
+                    commercial_area_id=r.commercial_area_id,
                     is_like=True if r.user_id else False,
                     open_status=operating_hours_to_open_status(
                         is_opened=r.is_opened,

--- a/app/schema/bakery.py
+++ b/app/schema/bakery.py
@@ -128,7 +128,7 @@ class GuDongMenuBakery(CommonBakery):
 
 
 class GuDongMenuBakeryResponseDTO(BaseModel):
-    items: List[GuDongMenuBakery]
+    items: List[GuDongMenuBakery] = Field(default=[])
     has_next: bool = Field(default=False, description="다음 페이지 유무")
 
 

--- a/app/schema/bakery.py
+++ b/app/schema/bakery.py
@@ -129,7 +129,7 @@ class GuDongMenuBakery(CommonBakery):
 
 class GuDongMenuBakeryResponseDTO(BaseModel):
     items: List[GuDongMenuBakery]
-    paging: Paging
+    has_next: bool = Field(default=False, description="다음 페이지 유무")
 
 
 class WrittenReview(BaseModel):

--- a/app/schema/bakery.py
+++ b/app/schema/bakery.py
@@ -60,7 +60,7 @@ class LoadMoreBakeryResponseDTO(BaseModel):
     """더보기 빵집 응답모델."""
 
     items: List[LoadMoreBakery] = Field(default=[], description="조회된 빵집 데이터.")
-    paging: Paging = Field(..., description="페이징 정보")
+    has_next: bool = Field(default=False, description="다음 페이지 유무")
 
 
 class BakeryDetail(BakeryMenu):

--- a/app/schema/review.py
+++ b/app/schema/review.py
@@ -51,7 +51,7 @@ class BakeryReviewReponseDTO(BaseModel):
     avg_rating: float = Field(default=0.0, description="리뷰 평균 별점")
     review_count: int = Field(default=0, description="리뷰 개수")
     items: List[BakeryReview] = Field(default=[], description="조회된 리뷰 데이터.")
-    paging: Paging = Field(..., description="페이징 정보")
+    has_next: bool = Field(default=False, description="다음 페이지 유무")
 
 
 class BakeryMyReviewReponseDTO(BaseModel):

--- a/app/schema/review.py
+++ b/app/schema/review.py
@@ -56,7 +56,7 @@ class BakeryReviewReponseDTO(BaseModel):
 
 class BakeryMyReviewReponseDTO(BaseModel):
     items: List[MyBakeryReview] = Field(default=[], description="조회된 리뷰 데이터.")
-    paging: Paging = Field(..., description="페이징 정보")
+    has_next: bool = Field(default=False, description="다음 페이지 유무")
 
 
 class ReviewLikeResponseDTO(BaseModel):

--- a/app/schema/search.py
+++ b/app/schema/search.py
@@ -9,6 +9,8 @@ from app.schema.common import Paging
 class SearchBakery(CommonBakery):
     """검색한 베이커리 정보"""
 
+    avg_rating: float = Field(..., description="평균별점")
+    review_count: int = Field(..., description="리뷰 개수")
     gu: str = Field(..., description="베이커리 자치구")
     dong: str = Field(..., description="베이커리 동")
     signature_menus: Optional[List[BakeryMenu]] = Field(
@@ -17,5 +19,5 @@ class SearchBakery(CommonBakery):
 
 
 class SearchBakeryResponseDTO(BaseModel):
-    items: List[SearchBakery] = Field(..., description="검색한 빵집 데이터")
-    paging: Paging = Field(..., description="페이징 객체")
+    items: List[SearchBakery] = Field(default=[], description="검색한 빵집 데이터")
+    has_next: bool = Field(default=False, description="다음 페이지 유무")

--- a/app/schema/search.py
+++ b/app/schema/search.py
@@ -13,6 +13,10 @@ class SearchBakery(CommonBakery):
     review_count: int = Field(..., description="리뷰 개수")
     gu: str = Field(..., description="베이커리 자치구")
     dong: str = Field(..., description="베이커리 동")
+    commercial_area_id: int = Field(
+        ...,
+        description="베이커리 상권지역코드 - 상세보기 클릭시 근처 관광지 추천에 필요",
+    )
     signature_menus: Optional[List[BakeryMenu]] = Field(
         default=[], description="시그니처 메뉴"
     )

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -88,7 +88,7 @@ class BakeryService:
         )
 
     async def get_hot_bakeries(
-        self, cursor_value: str, user_id: int, page_size: int, area_code: str
+        self, page_no: int, user_id: int, page_size: int, area_code: str
     ) -> LoadMoreBakeryResponseDTO:
         """(더보기용) hot한 빵집 조회하는 비즈니스 로직."""
 
@@ -105,17 +105,12 @@ class BakeryService:
             area_codes=area_codes,
             user_id=user_id,
             target_day_of_week=target_day_of_week,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
         )
 
         if not bakeries:
-            return LoadMoreBakeryResponseDTO(
-                items=[],
-                paging=Paging(
-                    prev_cursor=cursor_value, next_cursor=None, has_next=False
-                ),
-            )
+            return LoadMoreBakeryResponseDTO(items=[], has_next=False)
 
         # 빵 시그니처 메뉴 정보
         menus = await bakery_repo.get_signature_menus(
@@ -124,14 +119,7 @@ class BakeryService:
 
         bakery_infos = merge_menus_with_bakeries(bakeries=bakeries, menus=menus)
 
-        return LoadMoreBakeryResponseDTO(
-            items=bakery_infos,
-            paging=Paging(
-                prev_cursor=cursor_value,
-                next_cursor=to_cursor_str(bakeries[-1].bakery_id),
-                has_next=has_next,
-            ),
-        )
+        return LoadMoreBakeryResponseDTO(items=bakery_infos, has_next=has_next)
 
     async def get_bakery_detail(self, bakery_id: int):
         """베이커리 상세 조회하는 비즈니스 로직."""

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -39,7 +39,7 @@ class BakeryService:
         )
 
     async def get_more_bakeries_by_preference(
-        self, cursor_value: str, page_size: int, area_code: str, user_id: int
+        self, page_no: int, page_size: int, area_code: str, user_id: int
     ):
         """(더보기) 유저의 취향이 반영된 빵집 조회하는 비즈니스 로직."""
 
@@ -53,7 +53,7 @@ class BakeryService:
         # 베이커리 정보 조회
         bakery_repo = BakeryRepository(db=self.db)
         bakeries, has_next = await bakery_repo.get_more_bakeries_by_preference(
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
             area_codes=area_codes,
             user_id=user_id,
@@ -62,12 +62,7 @@ class BakeryService:
 
         # 베이커리 조회결과 없을 때, 반환값
         if not bakeries:
-            return LoadMoreBakeryResponseDTO(
-                items=[],
-                paging=Paging(
-                    prev_cursor=cursor_value, next_cursor=None, has_next=False
-                ),
-            )
+            return LoadMoreBakeryResponseDTO(items=[], has_next=False)
 
         # 베이커리 시그니처 메뉴 정보 조회
         menus = await bakery_repo.get_signature_menus(
@@ -77,14 +72,7 @@ class BakeryService:
         # 베이커리 정보 + 시그니처 메뉴 정보 병합
         bakery_infos = merge_menus_with_bakeries(bakeries=bakeries, menus=menus)
 
-        return LoadMoreBakeryResponseDTO(
-            items=bakery_infos,
-            paging=Paging(
-                prev_cursor=cursor_value,
-                next_cursor=to_cursor_str(bakeries[-1].bakery_id),
-                has_next=has_next,
-            ),
-        )
+        return LoadMoreBakeryResponseDTO(items=bakery_infos, has_next=has_next)
 
     async def get_bakery_by_area(self, area_code: str, user_id: int):
         """(홈탭용)hot한 빵집 조회하는 비즈니스 로직."""

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -62,7 +62,7 @@ class BakeryService:
 
         # 베이커리 조회결과 없을 때, 반환값
         if not bakeries:
-            return LoadMoreBakeryResponseDTO(items=[], has_next=False)
+            return LoadMoreBakeryResponseDTO(items=[])
 
         # 베이커리 시그니처 메뉴 정보 조회
         menus = await bakery_repo.get_signature_menus(
@@ -110,7 +110,7 @@ class BakeryService:
         )
 
         if not bakeries:
-            return LoadMoreBakeryResponseDTO(items=[], has_next=False)
+            return LoadMoreBakeryResponseDTO(items=[])
 
         # 빵 시그니처 메뉴 정보
         menus = await bakery_repo.get_signature_menus(
@@ -173,7 +173,7 @@ class BakeryService:
         )
 
         if not bakeries:
-            return GuDongMenuBakeryResponseDTO(items=[], has_next=False)
+            return GuDongMenuBakeryResponseDTO(items=[])
 
         # 2. 시그니처 메뉴 검색
         menus = await bakery_repo.get_signature_menus(

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -158,7 +158,7 @@ class BakeryService:
     async def get_bakery_menus(self, bakery_id: int):
         return await BakeryRepository(db=self.db).get_bakery_menus(bakery_id=bakery_id)
 
-    async def get_visited_bakery(self, user_id: int, cursor_value: str, page_size: int):
+    async def get_visited_bakery(self, user_id: int, page_no: int, page_size: int):
 
         bakery_repo = BakeryRepository(db=self.db)
 
@@ -168,19 +168,12 @@ class BakeryService:
         bakeries, has_next = await bakery_repo.get_visited_bakery(
             user_id=user_id,
             target_day_of_week=target_day_of_week,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
         )
 
         if not bakeries:
-            return GuDongMenuBakeryResponseDTO(
-                items=[],
-                paging=Paging(
-                    prev_cursor=cursor_value,
-                    next_cursor=None,
-                    has_next=False,
-                ),
-            )
+            return GuDongMenuBakeryResponseDTO(items=[], has_next=False)
 
         # 2. 시그니처 메뉴 검색
         menus = await bakery_repo.get_signature_menus(
@@ -189,14 +182,7 @@ class BakeryService:
 
         bakery_info = merge_menus_with_bakeries(bakeries=bakeries, menus=menus)
 
-        return GuDongMenuBakeryResponseDTO(
-            items=bakery_info,
-            paging=Paging(
-                prev_cursor=cursor_value,
-                next_cursor=to_cursor_str(bakeries[-1].bakery_id),
-                has_next=has_next,
-            ),
-        )
+        return GuDongMenuBakeryResponseDTO(items=bakery_info, has_next=has_next)
 
     async def check_is_eligible_to_write_review(self, bakery_id: int, user_id: int):
         """리뷰를 작성해도 되는지 체크하는 비즈니스 로직."""

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -62,7 +62,7 @@ class BakeryService:
 
         # 베이커리 조회결과 없을 때, 반환값
         if not bakeries:
-            return LoadMoreBakeryResponseDTO(items=[])
+            return LoadMoreBakeryResponseDTO()
 
         # 베이커리 시그니처 메뉴 정보 조회
         menus = await bakery_repo.get_signature_menus(
@@ -110,7 +110,7 @@ class BakeryService:
         )
 
         if not bakeries:
-            return LoadMoreBakeryResponseDTO(items=[])
+            return LoadMoreBakeryResponseDTO()
 
         # 빵 시그니처 메뉴 정보
         menus = await bakery_repo.get_signature_menus(
@@ -173,7 +173,7 @@ class BakeryService:
         )
 
         if not bakeries:
-            return GuDongMenuBakeryResponseDTO(items=[])
+            return GuDongMenuBakeryResponseDTO()
 
         # 2. 시그니처 메뉴 검색
         menus = await bakery_repo.get_signature_menus(

--- a/app/services/bakery_service.py
+++ b/app/services/bakery_service.py
@@ -222,7 +222,7 @@ class BakeryService:
         # 2. 해당 베이커리 찜 삭제
         await bakery_repo.dislike_bakery(user_id=user_id, bakery_id=bakery_id)
 
-    async def get_like_bakeries(self, user_id: int, cursor_value: str, page_size: int):
+    async def get_like_bakeries(self, user_id: int, page_no: int, page_size: int):
         """내가 찜한 빵집 조회하는 비즈니스 로직."""
 
         bakery_repo = BakeryRepository(db=self.db)
@@ -232,17 +232,12 @@ class BakeryService:
         bakeries, has_next = await bakery_repo.get_like_bakeries(
             user_id=user_id,
             target_day_of_week=target_day_of_week,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
         )
 
         if not bakeries:
-            return GuDongMenuBakeryResponseDTO(
-                items=[],
-                paging=Paging(
-                    prev_cursor=cursor_value, next_cursor=None, has_next=False
-                ),
-            )
+            return GuDongMenuBakeryResponseDTO()
 
         # 2. 메뉴 조회
         menus = await bakery_repo.get_signature_menus(
@@ -251,11 +246,4 @@ class BakeryService:
 
         bakery_infos = merge_menus_with_bakeries(bakeries=bakeries, menus=menus)
 
-        return GuDongMenuBakeryResponseDTO(
-            items=bakery_infos,
-            paging=Paging(
-                prev_cursor=cursor_value,
-                next_cursor=to_cursor_str(bakeries[-1].bakery_id),
-                has_next=has_next,
-            ),
-        )
+        return GuDongMenuBakeryResponseDTO(items=bakery_infos, has_next=has_next)

--- a/app/services/review_service.py
+++ b/app/services/review_service.py
@@ -32,7 +32,7 @@ class Review:
         self,
         user_id: int,
         bakery_id: int,
-        cursor_value: str,
+        page_no: int,
         page_size: int,
         sort_clause: str,
     ):
@@ -50,7 +50,7 @@ class Review:
         review_infos, has_next = await review_repo.get_review_by_bakery_id(
             user_id=user_id,
             bakery_id=bakery_id,
-            cursor_value=cursor_value,
+            page_no=page_no,
             sort_by=sort_by,
             direction=direction,
             page_size=page_size,
@@ -75,14 +75,10 @@ class Review:
             for r in review_menus:
                 review_menu_maps[r.review_id].append(ReviewMenu(menu_name=r.name))
 
-            # 4. next_cursor
-            sort_value = getattr(review_infos[-1], f"review_{sort_by}")
-            review_id = review_infos[-1].review_id
-            next_cursor = build_cursor(sort_value, review_id)
-
             return BakeryReviewReponseDTO(
                 avg_rating=avg_rating,
                 review_count=review_count,
+                has_next=has_next,
                 items=[
                     BakeryReview(
                         **r.model_dump(exclude={"review_photos", "review_menus"}),
@@ -91,15 +87,9 @@ class Review:
                     )
                     for r in review_infos
                 ],
-                paging=Paging(
-                    prev_cursor=cursor_value, next_cursor=next_cursor, has_next=has_next
-                ),
             )
 
-        return BakeryReviewReponseDTO(
-            items=[],
-            paging=Paging(prev_cursor=cursor_value, next_cursor=None, has_next=False),
-        )
+        return BakeryReviewReponseDTO(items=[])
 
     async def get_my_reviews_by_bakery_id(
         self, bakery_id: int, user_id: int, cursor_value: str, page_size: int

--- a/app/services/review_service.py
+++ b/app/services/review_service.py
@@ -89,10 +89,10 @@ class Review:
                 ],
             )
 
-        return BakeryReviewReponseDTO(items=[])
+        return BakeryReviewReponseDTO()
 
     async def get_my_reviews_by_bakery_id(
-        self, bakery_id: int, user_id: int, cursor_value: str, page_size: int
+        self, bakery_id: int, user_id: int, page_no: int, page_size: int
     ):
         """특정 베이커리에 내 리뷰 조회하는 비즈니스 로직."""
         review_repo = ReviewRepository(db=self.db)
@@ -101,7 +101,7 @@ class Review:
         review_infos, has_next = await review_repo.get_my_reviews_by_bakery_id(
             bakery_id=bakery_id,
             user_id=user_id,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
         )
 
@@ -133,21 +133,10 @@ class Review:
                     )
                     for r in review_infos
                 ],
-                paging=Paging(
-                    prev_cursor=cursor_value,
-                    next_cursor=to_cursor_str(review_infos[-1].review_id),
-                    has_next=has_next,
-                ),
+                has_next=has_next,
             )
 
-        return BakeryMyReviewReponseDTO(
-            items=[],
-            paging=Paging(
-                prev_cursor=cursor_value,
-                next_cursor=None,
-                has_next=False,
-            ),
-        )
+        return BakeryMyReviewReponseDTO()
 
     async def write_bakery_review(
         self,

--- a/app/services/search_service.py
+++ b/app/services/search_service.py
@@ -13,7 +13,7 @@ class SearchService:
         self.db = db
 
     async def search_bakeries_by_keyword(
-        self, keyword: str, user_id: int, cursor_value: str, page_size: int
+        self, keyword: str, user_id: int, page_no: int, page_size: int
     ):
         """키워드 검색 비즈니스 로직."""
 
@@ -26,19 +26,12 @@ class SearchService:
             keyword=keyword,
             user_id=user_id,
             target_day_of_week=target_day_of_week,
-            cursor_value=cursor_value,
+            page_no=page_no,
             page_size=page_size,
         )
 
         if not bakeries:
-            return SearchBakeryResponseDTO(
-                items=[],
-                paging=Paging(
-                    prev_cursor=cursor_value,
-                    next_cursor=None,
-                    has_next=False,
-                ),
-            )
+            return SearchBakeryResponseDTO()
 
         # 2. 베이커리 메뉴 검색
         menus = await BakeryRepository(db=self.db).get_signature_menus(
@@ -47,11 +40,4 @@ class SearchService:
 
         bakery_info = merge_menus_with_bakeries(bakeries=bakeries, menus=menus)
 
-        return SearchBakeryResponseDTO(
-            items=bakery_info,
-            paging=Paging(
-                prev_cursor=cursor_value,
-                next_cursor=to_cursor_str(bakery_info[-1].bakery_id),
-                has_next=has_next,
-            ),
-        )
+        return SearchBakeryResponseDTO(items=bakery_info, has_next=has_next)

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -59,3 +59,12 @@ def build_cursor(sort_value, review_id):
     """다음 페이지 요청 시 넘겨줄 커서 문자열 생성하는 메소드."""
 
     return f"{sort_value}||{review_id}"
+
+
+def convert_limit_and_offset(page_no: int, page_size: int):
+    """LIMIT OFFSET 반환하는 메소드."""
+
+    limit = page_size + 1
+    offset = (page_no - 1) * page_size
+
+    return limit, offset


### PR DESCRIPTION
## 🚀 Description
### 1. 페이징 구조 변경
- 기존 Cursor Paging에서 LIMIT OFFSET으로 변경
  - 클라쪽에서 이전데이터 캐싱로직 구현 안하기로 fix
  - cursor 페이징구조 시, prev_cursor 필드값에 요청 cusor_value가 아닌 진짜 prev_cursor값이 필요함
    - 클라쪽에서 페이징 구조체 내 key값이 중복되어 앱이 터져버림
    - prev_cursor값을 조회하기 위해선 반대 방향의 조회쿼리를 한 번 더 실행해야 함. ( 엄청난 비효율 )

> 상황 상 데이터가 몇 만 건 이상도 아니라서, 고도화된 처리보단 현실적인 처리 방안으로 재변경

### 2. 검색 시 상권지역 ID값도 response에 추가

### 3. 베이커리 중복데이터 이슈 수정